### PR TITLE
change the argument name "prob" to "mu"

### DIFF
--- a/impl/chapter2/bernoulli.py
+++ b/impl/chapter2/bernoulli.py
@@ -5,11 +5,11 @@ from .distribution import DiscreteDistribution
 
 class BernoulliDistribution(DiscreteDistribution):
 
-    def __init__(self, prob):
-        super(BernoulliDistribution, self).__init__(prob)
+    def __init__(self, mu):
+        super(BernoulliDistribution, self).__init__(mu)
         self.prob = {
-            0: 1 - prob,
-            1: prob,
+            0: 1 - mu,
+            1: mu,
         }
 
     def trial(self):


### PR DESCRIPTION
BernulliDistributionクラスの引数の名前がprobだと気持ち悪かったのでmuに変更しました。
これは現在実装中のBinomialDistributionクラスとの表記を統合したいために行いました。